### PR TITLE
Force 32-bit build for 32-bit distributions

### DIFF
--- a/scripts/ci/debian/rules
+++ b/scripts/ci/debian/rules
@@ -6,9 +6,15 @@
 
 # Note: Expects to be ran out of $(repo)/build/mono-llvm-3.9
 
+DEB_HOST_ARCH_BITS := $(shell dpkg-architecture -qDEB_HOST_ARCH_BITS)
+
+ifeq ($(DEB_HOST_ARCH_BITS), 32)
+        LINUX32 := linux32
+endif
+
 Makefile:
 	@echo "Building package for $(LLVM_TARGET)"
-	LDFLAGS="-L../../lib -lstdc++" cmake ../.. \
+	LDFLAGS="-L../../lib -lstdc++" $(LINUX32) cmake ../.. \
 		-DCMAKE_BUILD_TYPE=Release \
 		-DCMAKE_C_FLAGS="-I../../include -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -DNDEBUG -D__NO_CTYPE_INLINE -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS" \
 		-DCMAKE_CXX_FLAGS="-I../../include -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -DNDEBUG -D__NO_CTYPE_INLINE -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS" \


### PR DESCRIPTION
The LLVM build system detects a platform based on the running kernel, causing it to misdetect "native" arch as AArch64 on ARM chroots. Use the `linux32` command to force the kernel to be parsed as 32-bit where expected