### PR TITLE
Emit .fnstart/.fnend directives on arm ELF platforms in the mono EH w…

### DIFF
--- a/lib/CodeGen/AsmPrinter/MonoException.cpp
+++ b/lib/CodeGen/AsmPrinter/MonoException.cpp
@@ -254,6 +254,8 @@ MonoException::~MonoException()
 void
 MonoException::beginFunction(const MachineFunction *MF)
 {
+  if (DisableGNUEH && Asm->MAI->getExceptionHandlingType() == ExceptionHandling::ARM)
+    static_cast<ARMTargetStreamer*>(Asm->OutStreamer->getTargetStreamer())->emitFnStart();
   EHLabels.clear();
 }
 
@@ -414,6 +416,8 @@ MonoException::endFunction(const MachineFunction *MF)
   Frames.push_back(info);
   EHLabels.clear();
 
+  if (DisableGNUEH && Asm->MAI->getExceptionHandlingType() == ExceptionHandling::ARM)
+    static_cast<ARMTargetStreamer*>(Asm->OutStreamer->getTargetStreamer())->emitFnEnd();
 }
 
 /// EmitMonoLSDA - Mono's version of EmitExceptionTable


### PR DESCRIPTION
…riter since the ARM backends depends on ARMException doing it, and ARMException is not ran when --disable-gnu-eh-frame is given.