### PR TITLE
[mono] respect FloatABIType, so it will work on armv5

### DIFF
--- a/lib/Target/ARM/ARMISelLowering.cpp
+++ b/lib/Target/ARM/ARMISelLowering.cpp
@@ -1623,13 +1623,14 @@ CCAssignFn *ARMTargetLowering::CCAssignFnForNode(CallingConv::ID CC,
     if (Return) {
       return CCAssignFnForNode(CallingConv::C, true, isVarArg);
     } else {
-      if (Subtarget->isAAPCS_ABI()) {
-          if (Subtarget->hasVFP2() && !Subtarget->isThumb1Only() && !isVarArg)
-              return CC_ARM_Mono_AAPCS_VFP;
-          else
-              return CC_ARM_Mono_AAPCS;
-      } else
-          return CC_ARM_Mono_APCS;
+      if (!Subtarget->isAAPCS_ABI())
+        return CC_ARM_Mono_APCS;
+      else if (Subtarget->hasVFP2() && !Subtarget->isThumb1Only() &&
+               getTargetMachine().Options.FloatABIType == FloatABI::Hard &&
+               !isVarArg)
+        return CC_ARM_Mono_AAPCS_VFP;
+      else
+        return CC_ARM_Mono_AAPCS;
     }
   }
 }


### PR DESCRIPTION
Also changing the structure so it matches the `CallingConv::C` case in
`ARMTargetLowering::getEffectiveCallingConv()`.