### PR TITLE
Fixes Mono LLVM 6.0 for Windows x64.

### DIFF
--- a/include/llvm/IR/Operator.h
+++ b/include/llvm/IR/Operator.h
@@ -29,14 +29,15 @@ namespace llvm {
 /// This is a utility class that provides an abstraction for the common
 /// functionality between Instructions and ConstantExprs.
 class Operator : public User {
-public:
+protected:
   // The Operator class is intended to be used as a utility, and is never itself
   // instantiated.
-  Operator() = delete;
-  ~Operator() = delete;
+  Operator() = default;
+  ~Operator() = default;
 
   void *operator new(size_t s) = delete;
 
+public:
   /// Return the opcode for this Instruction or ConstantExpr.
   unsigned getOpcode() const {
     if (const Instruction *I = dyn_cast<Instruction>(this))

--- a/include/llvm/IR/User.h
+++ b/include/llvm/IR/User.h
@@ -103,6 +103,9 @@ public:
   void operator delete(void*, unsigned) {
     llvm_unreachable("Constructor throws?");
   }
+  void operator delete(void*, unsigned, unsigned) {
+    llvm_unreachable("Constructor throws?");
+  }
   /// \brief Placement delete - required by std, but never called.
   void operator delete(void*, unsigned, bool) {
     llvm_unreachable("Constructor throws?");

--- a/lib/AsmParser/LLLexer.cpp
+++ b/lib/AsmParser/LLLexer.cpp
@@ -613,6 +613,7 @@ lltok::Kind LLLexer::LexIdentifier() {
   KEYWORD(amdgpu_ps);
   KEYWORD(amdgpu_cs);
   KEYWORD(amdgpu_kernel);
+  KEYWORD(monocc);
 
   KEYWORD(cc);
   KEYWORD(c);

--- a/lib/AsmParser/LLParser.cpp
+++ b/lib/AsmParser/LLParser.cpp
@@ -1746,6 +1746,7 @@ void LLParser::ParseOptionalDLLStorageClass(unsigned &Res) {
 ///   ::= 'amdgpu_ps'
 ///   ::= 'amdgpu_cs'
 ///   ::= 'amdgpu_kernel'
+///   ::= 'monocc'
 ///   ::= 'cc' UINT
 ///
 bool LLParser::ParseOptionalCallingConv(unsigned &CC) {
@@ -1790,6 +1791,7 @@ bool LLParser::ParseOptionalCallingConv(unsigned &CC) {
   case lltok::kw_amdgpu_ps:      CC = CallingConv::AMDGPU_PS; break;
   case lltok::kw_amdgpu_cs:      CC = CallingConv::AMDGPU_CS; break;
   case lltok::kw_amdgpu_kernel:  CC = CallingConv::AMDGPU_KERNEL; break;
+  case lltok::kw_monocc:         CC = CallingConv::Mono; break;
   case lltok::kw_cc: {
       Lex.Lex();
       return ParseUInt32(CC);

--- a/lib/AsmParser/LLToken.h
+++ b/lib/AsmParser/LLToken.h
@@ -165,6 +165,7 @@ enum Kind {
   kw_amdgpu_ps,
   kw_amdgpu_cs,
   kw_amdgpu_kernel,
+  kw_monocc,
 
   // Attributes:
   kw_attributes,

--- a/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -355,7 +355,10 @@ bool AsmPrinter::doInitialization(Module &M) {
       break;
     case WinEH::EncodingType::X86:
     case WinEH::EncodingType::Itanium:
-      ES = new WinException(this);
+      if (!EnableMonoEH)
+        ES = new WinException(this);
+      else
+        ES = new WinException(this, true);
       break;
     }
     break;

--- a/lib/CodeGen/AsmPrinter/MonoException.cpp
+++ b/lib/CodeGen/AsmPrinter/MonoException.cpp
@@ -447,8 +447,6 @@ MonoException::EmitMonoLSDA(const EHInfo *info)
           [](const LandingPadInfo *L,
 			 const LandingPadInfo *R) { return L->TypeIds < R->TypeIds; });
 
-  assert(Asm->MAI->getExceptionHandlingType() == ExceptionHandling::DwarfCFI);
-
   // The type_info itself is emitted
   int TTypeEncoding = dwarf::DW_EH_PE_udata4;
 

--- a/lib/CodeGen/AsmPrinter/WinException.h
+++ b/lib/CodeGen/AsmPrinter/WinException.h
@@ -35,6 +35,9 @@ class LLVM_LIBRARY_VISIBILITY WinException : public EHStreamer {
   /// Per-function flag to indicate if frame moves info should be emitted.
   bool shouldEmitMoves = false;
 
+  /// Per-function flag to indicate if personality info should be disabled.
+  bool disableEmitPersonality = false;
+
   /// True if this is a 64-bit target and we should use image relative offsets.
   bool useImageRel32 = false;
 
@@ -88,6 +91,7 @@ public:
   // Main entry points.
   //
   WinException(AsmPrinter *A);
+  WinException(AsmPrinter *A, bool disableEmitPersonality);
   ~WinException() override;
 
   /// Emit all exception information that should come after the content.

--- a/lib/IR/AsmWriter.cpp
+++ b/lib/IR/AsmWriter.cpp
@@ -380,6 +380,7 @@ static void PrintCallingConv(unsigned cc, raw_ostream &Out) {
   case CallingConv::AMDGPU_PS:     Out << "amdgpu_ps"; break;
   case CallingConv::AMDGPU_CS:     Out << "amdgpu_cs"; break;
   case CallingConv::AMDGPU_KERNEL: Out << "amdgpu_kernel"; break;
+  case CallingConv::Mono:          Out << "monocc"; break;
   }
 }
 

--- a/lib/Target/X86/X86CallingConv.td
+++ b/lib/Target/X86/X86CallingConv.td
@@ -706,6 +706,9 @@ def CC_X86_64_AnyReg : CallingConv<[
 def CC_X86_64_Mono : CallingConv<[
   CCIfInReg<CCAssignToReg<[R10]>>,
 
+  // Mingw64 and native Win64 use Win64 CC
+  CCIfSubtarget<"isTargetWin64()", CCDelegateTo<CC_X86_Win64_C>>,
+  // Otherwise, drop to normal X86-64 CC
   CCDelegateTo<CC_X86_64_C>
 ]>;
 

--- a/lib/Target/X86/X86FastISel.cpp
+++ b/lib/Target/X86/X86FastISel.cpp
@@ -1166,6 +1166,9 @@ bool X86FastISel::X86SelectRet(const Instruction *I) {
     return false;
 
   CallingConv::ID CC = F.getCallingConv();
+  if (CC == CallingConv::Mono && Subtarget->isTargetWin64())
+    CC = CallingConv::Win64;
+
   if (CC != CallingConv::C &&
       CC != CallingConv::Fast &&
       CC != CallingConv::X86_FastCall &&
@@ -3175,6 +3178,9 @@ bool X86FastISel::fastLowerCall(CallLoweringInfo &CLI) {
   // Functions using retpoline should use SDISel for calls.
   if (Subtarget->useRetpoline())
     return false;
+
+  if (CC == CallingConv::Mono && Subtarget->isTargetWin64())
+    CC = CallingConv::Win64;
 
   // Handle only C, fastcc, and webkit_js calling conventions for now.
   switch (CC) {

--- a/lib/Target/X86/X86FrameLowering.cpp
+++ b/lib/Target/X86/X86FrameLowering.cpp
@@ -960,7 +960,9 @@ void X86FrameLowering::emitPrologue(MachineFunction &MF,
       !IsFunclet && STI.isTargetWin32() && MMI.getModule()->getCodeViewFlag();
   bool NeedsWinCFI = NeedsWin64CFI || NeedsWinFPO;
   bool NeedsDwarfCFI =
-      !IsWin64Prologue && (MMI.hasDebugInfo() || Fn.needsUnwindTableEntry());
+      Fn.getCallingConv() == CallingConv::Mono
+          ? (MMI.hasDebugInfo() || Fn.needsUnwindTableEntry())
+          : !IsWin64Prologue && (MMI.hasDebugInfo() || Fn.needsUnwindTableEntry());
   unsigned FramePtr = TRI->getFrameRegister(MF);
   const unsigned MachineFramePtr =
       STI.isTarget64BitILP32()

--- a/lib/Target/X86/X86ISelLowering.cpp
+++ b/lib/Target/X86/X86ISelLowering.cpp
@@ -2706,7 +2706,9 @@ static bool canGuaranteeTCO(CallingConv::ID CC) {
 }
 
 /// Return true if we might ever do TCO for calls with this calling convention.
-static bool mayTailCallThisCC(CallingConv::ID CC) {
+static bool mayTailCallThisCC(CallingConv::ID CC, bool isTargetWin64) {
+  if (CC == CallingConv::Mono && isTargetWin64)
+    CC = CallingConv::Win64;
   switch (CC) {
   // C calling conventions:
   case CallingConv::C:
@@ -2737,7 +2739,7 @@ bool X86TargetLowering::mayBeEmittedAsTailCall(const CallInst *CI) const {
 
   ImmutableCallSite CS(CI);
   CallingConv::ID CalleeCC = CS.getCallingConv();
-  if (!mayTailCallThisCC(CalleeCC))
+  if (!mayTailCallThisCC(CalleeCC, Subtarget.isTargetWin64()))
     return false;
 
   return true;
@@ -4050,7 +4052,7 @@ bool X86TargetLowering::IsEligibleForTailCallOptimization(
     const SmallVectorImpl<ISD::OutputArg> &Outs,
     const SmallVectorImpl<SDValue> &OutVals,
     const SmallVectorImpl<ISD::InputArg> &Ins, SelectionDAG &DAG) const {
-  if (!mayTailCallThisCC(CalleeCC))
+  if (!mayTailCallThisCC(CalleeCC, Subtarget.isTargetWin64()))
     return false;
 
   // If -tailcallopt is specified, make fastcc functions tail-callable.

--- a/lib/Target/X86/X86RegisterInfo.cpp
+++ b/lib/Target/X86/X86RegisterInfo.cpp
@@ -279,6 +279,9 @@ X86RegisterInfo::getCalleeSavedRegs(const MachineFunction *MF) const {
   if (MF->getFunction().hasFnAttribute("no_caller_saved_registers"))
     CC = CallingConv::X86_INTR;
 
+  if (CC == CallingConv::Mono && IsWin64)
+    CC = CallingConv::Win64;
+
   switch (CC) {
   case CallingConv::GHC:
   case CallingConv::HiPE:
@@ -393,6 +396,9 @@ X86RegisterInfo::getCallPreservedMask(const MachineFunction &MF,
   bool HasSSE = Subtarget.hasSSE1();
   bool HasAVX = Subtarget.hasAVX();
   bool HasAVX512 = Subtarget.hasAVX512();
+
+  if ( CC == CallingConv::Mono && IsWin64)
+    CC = CallingConv::Win64;
 
   switch (CC) {
   case CallingConv::GHC:

--- a/lib/Target/X86/X86Subtarget.h
+++ b/lib/Target/X86/X86Subtarget.h
@@ -673,6 +673,7 @@ public:
     case CallingConv::X86_ThisCall:
     case CallingConv::X86_VectorCall:
     case CallingConv::Intel_OCL_BI:
+    case CallingConv::Mono:
       return isTargetWin64();
     // This convention allows using the Win64 convention on other targets.
     case CallingConv::Win64:

--- a/lib/Transforms/Instrumentation/MemorySanitizer.cpp
+++ b/lib/Transforms/Instrumentation/MemorySanitizer.cpp
@@ -3182,15 +3182,23 @@ struct VarArgAMD64Helper : public VarArgHelper {
     // nonzero shadow.
   }
 
+  bool isTargetWin64() const {
+    Triple TargetTriple(F.getParent()->getTargetTriple());
+    return TargetTriple.isArch64Bit() && TargetTriple.isOSWindows();
+  }
+
   void visitVAStartInst(VAStartInst &I) override {
-    if (F.getCallingConv() == CallingConv::Win64)
+    if (F.getCallingConv() == CallingConv::Win64 ||
+        F.getCallingConv() == CallingConv::Mono && isTargetWin64())
       return;
     VAStartInstrumentationList.push_back(&I);
     unpoisonVAListTagForInst(I);
   }
 
   void visitVACopyInst(VACopyInst &I) override {
-    if (F.getCallingConv() == CallingConv::Win64) return;
+    if (F.getCallingConv() == CallingConv::Win64 ||
+        F.getCallingConv() == CallingConv::Mono && isTargetWin64())
+      return;
     unpoisonVAListTagForInst(I);
   }
 


### PR DESCRIPTION
* Adjust mono's LLVM calling convention to use win64 calling convention.
* Emit both Windows native unwind info + Dwarf unwind info for mono methods.
* Don't emit native personality handlers for mono methods.
* Handle Mono and Win64 calling convention similarities when needed.