### PR TITLE
Use absolute paths when running run-jenkins-*.sh scripts.

### DIFF
--- a/scripts/ci/.gitattributes
+++ b/scripts/ci/.gitattributes
@@ -1,0 +1,5 @@
+# Windows line ending
+run-jenkins-windows.bat text eol=crlf
+setup-windows-env.bat text eol=crlf
+setup-vs-msvcbuild-env.bat text eol=crlf
+build-external-llvm.bat text eol=crlf

--- a/scripts/ci/.gitignore
+++ b/scripts/ci/.gitignore
@@ -1,0 +1,3 @@
+builds
+out
+*.tar.gz

--- a/scripts/ci/run-jenkins-linux.sh
+++ b/scripts/ci/run-jenkins-linux.sh
@@ -1,6 +1,8 @@
 #!/bin/bash -e
 
+RUN_JENKINS_LINUX_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 echo "ENVIRONMENT:"
 env
 
-./package.sh
+$RUN_JENKINS_LINUX_SCRIPT_DIR/package.sh

--- a/scripts/ci/run-jenkins-windows.sh
+++ b/scripts/ci/run-jenkins-windows.sh
@@ -27,7 +27,7 @@ function win32_format_path {
 echo "ENVIRONMENT:"
 env
 
-RUN_JENKINS_WINDOWS_SCRIPT_PATH=$(cd "$(dirname "$0")"; pwd)
+RUN_JENKINS_WINDOWS_SCRIPT_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 RUN_JENKINS_WINDOWS_SCRIPT_PATH=$(win32_format_path "$RUN_JENKINS_WINDOWS_SCRIPT_PATH/run-jenkins-windows.bat")
 
 WINDOWS_CMD=$(which cmd.exe)

--- a/scripts/ci/run-jenkins.sh
+++ b/scripts/ci/run-jenkins.sh
@@ -1,22 +1,24 @@
 #!/bin/bash -e
 
+RUN_JENKINS_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 host_uname="$(uname)"
 case "$host_uname" in
     CYGWIN*)
-        ./run-jenkins-windows.sh
+        $RUN_JENKINS_SCRIPT_DIR/run-jenkins-windows.sh
         ;;
     Linux)
         host_uname="$(uname -a)"
         case "$host_uname" in
             *Microsoft*)
-                ./run-jenkins-windows.sh
+                $RUN_JENKINS_SCRIPT_DIR/run-jenkins-windows.sh
                 ;;
             *)
-                ./run-jenkins-linux.sh
+                $RUN_JENKINS_SCRIPT_DIR/run-jenkins-linux.sh
                 ;;
         esac
         ;;
     Darwin)
-        ./run-jenkins-osx.sh
+        $RUN_JENKINS_SCRIPT_DIR/run-jenkins-osx.sh
         ;;
 esac


### PR DESCRIPTION
Fix checkout of needed .bat files setting crlf using local .gitattributes.

Ignore build artifacts using local .gitignore.