### PR TITLE
Create new labels for each CFI MachineInstr. (LLVM 9)

### DIFF
--- a/lib/CodeGen/AsmPrinter/MonoException.cpp
+++ b/lib/CodeGen/AsmPrinter/MonoException.cpp
@@ -220,19 +220,22 @@ static void
 emitCFIInstructions(MCStreamer &streamer,
                     const std::vector<MCCFIInstruction> &Instrs,
                     MCSymbol *BaseLabel,
-                    const std::vector<MCSymbol*> *Labels,
+                    const std::vector<MonoLabeledCfiInstruction> &labeled_cfi,
                     int &CFAOffset,
                     int DataAlignmentFactor)
 {
-  for (unsigned i = 0, N = Instrs.size(); i < N; ++i) {
-    const MCCFIInstruction &Instr = Instrs[i];
-    MCSymbol *Label = Labels ? ((*Labels)[i]) : NULL;
+  for (const auto &lblcfi : labeled_cfi) {
+    const auto ix = lblcfi.CfiIndex;
+    const auto Label = lblcfi.Label;
+    const auto &Instr = Instrs.at(ix);
+    // Throw out move if the Label is invalid.
+    if (Label && !Label->isDefined()) continue; // Not emitted, in dead code.
 
     // Advance row if new location.
     if (BaseLabel && Label) {
       MCSymbol *ThisSym = Label;
       if (ThisSym != BaseLabel) {
-        streamer.AddComment ("cfa_advance");
+        streamer.AddComment("cfa_advance");
         streamer.EmitDwarfAdvanceFrameAddr(BaseLabel, ThisSym);
         BaseLabel = ThisSym;
       }
@@ -257,7 +260,7 @@ void
 MonoException::beginFunction(const MachineFunction *MF)
 {
   EmitFnStart();
-  EHLabels.clear();
+  CfiInstructions.clear();
 }
 
 void
@@ -418,11 +421,10 @@ MonoException::endFunction(const MachineFunction *MF)
   info.FunctionNumber = Asm->getFunctionNumber();
   info.BeginSym = Asm->getFunctionBegin ();
   info.EndSym = Asm->getFunctionEnd ();
-  info.EHLabels = EHLabels;
   info.MonoMethodIdx = monoMethodIdx;
   info.HasLandingPads = !MF->getLandingPads().empty();
   info.Instructions = MF->getFrameInstructions();
-  assert (info.Instructions.size () == info.EHLabels.size());
+  info.CfiInstructions = std::move(CfiInstructions);
 
   if (DisableGNUEH)
     /* ARMAsmPrinter generates references to this */
@@ -431,7 +433,6 @@ MonoException::endFunction(const MachineFunction *MF)
   PrepareMonoLSDA(&info);
 
   Frames.push_back(info);
-  EHLabels.clear();
 
   EmitFnEnd ();
 }
@@ -611,7 +612,12 @@ MonoException::endModule()
   int cfaOffset = 0;
 
   // Initial CIE program
-  emitCFIInstructions(streamer, streamer.getContext().getAsmInfo()->getInitialFrameState(), NULL, NULL, cfaOffset, stackGrowth);
+  std::vector<MonoLabeledCfiInstruction> cieInstructions;
+  const unsigned int cieSize = streamer.getContext().getAsmInfo()->getInitialFrameState().size();
+  for (unsigned int i = 0; i < cieSize; ++i) {
+    cieInstructions.push_back({ nullptr, i });
+  }
+  emitCFIInstructions(streamer, streamer.getContext().getAsmInfo()->getInitialFrameState(), nullptr, cieInstructions, cfaOffset, stackGrowth);
   streamer.AddComment("End of CIE program");
   streamer.EmitIntValue(dwarf::DW_CFA_nop, 1);
 
@@ -646,7 +652,7 @@ MonoException::endModule()
 
       // Emit unwind info
       cfaOffset = cieCfaOffset;
-      emitCFIInstructions(streamer, info.Instructions, info.BeginSym, &info.EHLabels, cfaOffset, dataAlignmentFactor);
+      emitCFIInstructions(streamer, info.Instructions, info.BeginSym, info.CfiInstructions, cfaOffset, dataAlignmentFactor);
 
       streamer.AddBlankLine();
   }
@@ -658,18 +664,10 @@ MonoException::endModule()
 void
 MonoException::beginInstruction(const MachineInstr *MI)
 {
-	if (MI->getOpcode() == TargetOpcode::CFI_INSTRUCTION) {
-		unsigned CFIIndex = MI->getOperand(0).getCFIIndex();
-
-		//outs () << "D: " << CFIIndex << " " << EHLabels.size() << "\n";
-
-		/* Emit a label and save the label-cfi index association */
-		if (CFIIndex != EHLabels.size())
-			assert (0);
-
-		MCSymbol *Label = Asm->OutContext.createTempSymbol();
-		Asm->OutStreamer->EmitLabel(Label);
-
-		EHLabels.push_back(Label);
-	}
+  if (MI->getOpcode() == TargetOpcode::CFI_INSTRUCTION) {
+    const auto cfiIndex = MI->getOperand(0).getCFIIndex();
+    const auto label = Asm->OutContext.createTempSymbol();
+    Asm->OutStreamer->EmitLabel(label);
+    CfiInstructions.push_back({ label, cfiIndex });
+  }
 }

--- a/lib/CodeGen/AsmPrinter/MonoException.h
+++ b/lib/CodeGen/AsmPrinter/MonoException.h
@@ -17,6 +17,11 @@ namespace llvm {
 
 class TargetRegisterInfo;
 
+struct MonoLabeledCfiInstruction {
+  MCSymbol *Label;
+  unsigned int CfiIndex;
+};
+
 class MonoException : public EHStreamer {
 public:
     MonoException(AsmPrinter *A, bool disableGNUEH);
@@ -45,11 +50,11 @@ private:
   struct EHInfo {
     int FunctionNumber, MonoMethodIdx;
 	MCSymbol *BeginSym, *EndSym, *FDESym;
-	std::vector<MCSymbol*> EHLabels;
     std::vector<MCCFIInstruction> Instructions;
     std::vector<MonoCallSiteEntry> CallSites;
     std::vector<const GlobalValue *> TypeInfos;
     std::vector<LandingPadInfo> PadInfos;
+    std::vector<MonoLabeledCfiInstruction> CfiInstructions;
     int FrameReg;
     int ThisOffset;
     bool HasLandingPads;
@@ -70,7 +75,7 @@ private:
   void EmitFnStart();
   void EmitFnEnd();
 
-  std::vector<MCSymbol*> EHLabels;
+  std::vector<MonoLabeledCfiInstruction> CfiInstructions;
   std::vector<EHInfo> Frames;
   StringMap<int> FuncIndexes;
   const TargetRegisterInfo *RI;


### PR DESCRIPTION
Avoids assertion failures and attempts at backwards address advancement
when CFI indices are reused across multiple CFI MachineInstrs.
MCCFIInstruction::getLabel can't be used here, because the
MCCFIInstructions accumulated during frame lowering all have nullptr
labels.

Fixes mono/mono#8791.