### PR TITLE
Add a flag to disable emission of .llvm_faultmaps metadata.

### DIFF
--- a/lib/CodeGen/FaultMaps.cpp
+++ b/lib/CodeGen/FaultMaps.cpp
@@ -21,6 +21,10 @@
 
 using namespace llvm;
 
+static cl::opt<bool> DisableFaultMaps("disable-fault-maps",
+  cl::desc("Disables emission of fault map metadata."),
+  cl::init(false), cl::Hidden);
+
 #define DEBUG_TYPE "faultmaps"
 
 static const int FaultMapVersion = 1;
@@ -48,6 +52,8 @@ void FaultMaps::recordFaultingOp(FaultKind FaultTy,
 }
 
 void FaultMaps::serializeToFaultMapSection() {
+  if (DisableFaultMaps)
+    return;
   if (FunctionInfos.empty())
     return;
 


### PR DESCRIPTION
We don't use this section at all inside Mono. Rather than stripping the section using a platform-specific tool after it has been generated, just avoid generating the section in the first place.